### PR TITLE
orthography mappings

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,40 @@ This repository contains scripts and documentation for managing ALTLab's Woods C
 
 The database uses the [Data Format for Digital Linguistics][DaFoDiL] as its underlying data format—a set of recommendations for storing linguistic data in JSON.
 
+## Orthography
+
+The following table shows each grapheme in Woods Cree in the Colin Charles' Modified Roman Orthography (CMRO) and its equivalent in the Standard Roman Orthography (SRO), also with its corresponding value in the International Phonetic Alphabet (IPA).
+
+<style>
+table {
+  font-family:
+    'Gentium Plus',
+    'Charis SIL',
+    'Linux Libertine',
+    'Noto Serif';
+}
+</style>
+
+  IPA     | CMRO | SRO
+:--------:|:----:|:--:
+   ə      |  u   |  a
+  aː      |  a   |  â
+t͡ʃ ~ t͡s |  ch  |  c
+   h      |  h   |  h
+   ɪ      |  i   |  i
+  iː      |  e   |  î
+   k      |  k   |  k
+   m      |  m   |  m
+   n      |  n   |  n
+ o ~ ʊ    |  o   |  o
+oː ~ uː   |  oo  |  ô
+   p      |  p   |  p
+ s ~ ʃ    |  s   |  s
+   t      |  t   |  t
+   ð      |  th  | th
+   w      |  w   |  w
+   y      |  y   |  y
+
 ## Sources
 
 ALTLab's dictionary database is / will be aggregated from the following sources:

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ oː ~ uː   |  oo  |  ô
    t      |  t   |  t
    ð      |  th  | th
    w      |  w   |  w
-   y      |  y   |  y
+   j      |  y   |  y
 
 ## Sources
 

--- a/README.md
+++ b/README.md
@@ -10,16 +10,6 @@ The database uses the [Data Format for Digital Linguistics][DaFoDiL] as its unde
 
 The following table shows each grapheme in Woods Cree in the Colin Charles' Modified Roman Orthography (CMRO) and its equivalent in the Standard Roman Orthography (SRO), also with its corresponding value in the International Phonetic Alphabet (IPA).
 
-<style>
-table {
-  font-family:
-    'Gentium Plus',
-    'Charis SIL',
-    'Linux Libertine',
-    'Noto Serif';
-}
-</style>
-
   IPA     | CMRO | SRO
 :--------:|:----:|:--:
    ə      |  u   |  a


### PR DESCRIPTION
This PR adds a table to the readme which shows the mappings between different orthographies in Woods Cree. The table shows the IPA, the CMRO, and SRO equivalents for each phoneme in the language.

A tilde in the IPA column (`~`) indicates an alternation between allophones, i.e. that phoneme can be pronounced in multiple ways.

**Note:** I'd particularly appreciate a double check on the allophones. Does Woods Cree actually have all the allophones listed?